### PR TITLE
Intelligently use http or https

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's what the include tag should look like. The
       "permalink": "http://example.com/projects/%PROJECT_ID%/items/%ITEM_ID%"
     };
     var s = document.createElement('script');
-    s.src = 'https://platform.harvestapp.com/assets/platform.js';
+    s.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://platform.harvestapp.com/assets/platform.js';
     s.async = true;
     var ph = document.getElementsByTagName('script')[0];
     ph.parentNode.insertBefore(s, ph);


### PR DESCRIPTION
We shouldn't pull this over HTTPS if it's not necessary.  It'll be a lot slower:

```
$ ab -n 100 http://platform.harvestapp.com/assets/platform.js

Time taken for tests:   23.060 seconds
Requests per second:    4.34 [#/sec] (mean)
Time per request:       230.596 [ms] (mean)

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:       74   75   1.4     74      83
Processing:   150  156  42.2    150     572
Waiting:       75   76   2.6     75      97
Total:        224  231  42.4    225     648


$ ab -n 100 https://platform.harvestapp.com/assets/platform.js

Time taken for tests:   39.241 seconds
Requests per second:    2.55 [#/sec] (mean)
Time per request:       392.411 [ms] (mean)

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:      236  241   4.0    239     259
Processing:   150  152   2.3    151     168
Waiting:       75   77   2.2     76      94
Total:        387  392   4.9    391     411
```

This new code uses the protocol of the including page.

We should probably do the same thing with the stylesheet that gets included (and anything else that I'm not thinking of).  But that's application-side stuff -- I'll do this easy one and leave that as an exercise to the reader.
