### PR TITLE
Use new object-based message format.

### DIFF
--- a/widget.md
+++ b/widget.md
@@ -35,14 +35,12 @@ The height of the content within the frame changes as the user interacts with th
 
 ```javascript
 window.addEventListener("message", function (event) {
-  var matches;
-
   if (event.origin != "https://platform.harvestapp.com") {
     return;
   }
 
-  if (matches = event.data.match(/height:([0-9]+)/)) {
-    document.querySelector("iframe").style.height = matches[1] + "px";
+  if (event.data.type == "frame:resize") {
+    document.querySelector("iframe").style.height = event.data.value + "px";
   }
 });
 ```


### PR DESCRIPTION
@pusewicz 

Instead of our janky string-based message format, use the newer object-based message format that we’re about to support in Harvestapp.

Assuming that [the related change in Harvestapp](https://github.com/harvesthq/harvestapp/pull/7690) goes through without issue, this will be the documentation change needed. 