### PR TITLE
Add Evan's video to GitHub Button documentation

### DIFF
--- a/button.md
+++ b/button.md
@@ -86,4 +86,4 @@ document.querySelector("#harvest-messaging").dispatchEvent(event);
 
 ## Watch a Demo
 
-Watch a [live demo](https://www.youtube.com/watch?v=-9p1L8ED9Us) of how to integrate the Harvest Platform.
+Watch a [live demo](https://www.youtube.com/watch?v=-9p1L8ED9Us) of how to integrate the Harvest Button.

--- a/button.md
+++ b/button.md
@@ -83,3 +83,7 @@ var event = new CustomEvent("harvest-event:timers:add", {
 });
 document.querySelector("#harvest-messaging").dispatchEvent(event);
 ```
+
+## Watch a Demo
+
+Watch a [live demo](https://www.youtube.com/watch?v=-9p1L8ED9Us) of how to integrate the Harvest Platform.


### PR DESCRIPTION
Since we're no longer showing the link to the video on the marketing page, I wanted to add it to the GitHub Button documentation. Running it by you guys to confirm [this video](https://www.youtube.com/watch?v=-9p1L8ED9Us) is still applicable @adunkman @pusewicz @braddunbar. Thanks!