### PR TITLE
Add Group parameters to widget example.

### DIFF
--- a/widget.md
+++ b/widget.md
@@ -9,7 +9,9 @@ This embedded `<iframe>` allows you to embed a Harvest Timer form directly into 
     closable=false&
     permalink=https%3A%2F%2Fexample.com%2Fitem%2F1&
     external_item_id=1&
-    external_item_name=Programming">
+    external_item_name=Programming&
+    external_group_id=2&
+    external_group_name=TPS%20Reports">
 </iframe>
 ```
 


### PR DESCRIPTION
@notdoug @harvesthq/ocho-js

While the group id and name are not required for the widget to work generally, it will not display existing running timers without them so let's include them in our example!