### PR TITLE
remove white space from iframe example.

### DIFF
--- a/widget.md
+++ b/widget.md
@@ -3,15 +3,7 @@
 This embedded `<iframe>` allows you to embed a Harvest Timer form directly into your application. Create an `<iframe>` like this:
 
 ```
-<iframe
-  src="https://platform.harvestapp.com/platform/timer?
-    app_name=ExampleCompany&
-    closable=false&
-    permalink=https%3A%2F%2Fexample.com%2Fitem%2F1&
-    external_item_id=1&
-    external_item_name=Programming&
-    external_group_id=2&
-    external_group_name=TPS%20Reports">
+<iframe src="https://platform.harvestapp.com/platform/timer?app_name=ExampleCompany&closable=false&permalink=https%3A%2F%2Fexample.com%2Fitem%2F1&external_item_id=1&external_item_name=Programming&external_group_id=2&external_group_name=TPS%20Reports">
 </iframe>
 ```
 


### PR DESCRIPTION
@notdoug @harvesthq/harvest-developers 

The white space in the iframe url is pretty, but it creates issues because Harvest is getting parameters like `"     external_group_id"` instead of `"external_group_id"`.

Correct and hard to read is better than beautiful but broken!